### PR TITLE
Updated URL link to tutorial page

### DIFF
--- a/_site/philosophy.html
+++ b/_site/philosophy.html
@@ -161,7 +161,7 @@ ul.task-list li input[type="checkbox"] {
 <p>Our introductory classes in statistics and data science use too much mathematics. The key causal effect which our students want our classes to have is to improve their future performance and opportunities. The more professional their computing skills (in the context of data analysis), the greater their likely success. Introductory courses should feature almost no mathematical/statistical formulas beyond simple algebra.</p>
 </blockquote>
 <p>Any introductory course which, for example, does not teach Git/Github is doing its students a disservice.</p>
-<p>Third, the heart of the course are the <a href="https://ppbds.github.io/primer.tutorials/">tutorials</a> which students complete on their own. This <a href="https://ppbds.github.io/primer.tutorials/articles/instructions.html">essay</a> about how to write tutorials provides some background details. Highlights:</p>
+<p>Third, the heart of the course are the <a href="https://ppbds.github.io/all.primer.tutorials/">tutorials</a> which students complete on their own. This <a href="https://ppbds.github.io/all.primer.tutorials/articles/instructions.html">essay</a> about how to write tutorials provides some background details. Highlights:</p>
 <blockquote class="blockquote">
 <p>Imagine the shallowest possible learning curve. Almost every student should be able to answer almost every Exercise, albeit perhaps with the help of the Hint. There are no hard questions. In fact, there really aren’t questions at all. Instead, there are instructions: Do this. Do that. Next do this other thing.</p>
 </blockquote>

--- a/_site/schedule.html
+++ b/_site/schedule.html
@@ -139,7 +139,7 @@ ul.task-list li input[type="checkbox"] {
 </header>
 
 <p>Classes run from 8:00 to 9:00 PM EDT on Mondays, Wednesdays and Thursdays.</p>
-<p>Two key resources: <a href="https://ppbds.github.io/primer/"><em>Preceptor’s Primer for Bayesian Data Science</em></a> and its <a href="https://ppbds.github.io/primer.tutorials/">associated tutorials</a>. Assignments associated with a specific lecture must be completed before that lecture.</p>
+<p>Two key resources: <a href="https://ppbds.github.io/primer/"><em>Preceptor’s Primer for Bayesian Data Science</em></a> and its <a href="https://ppbds.github.io/all.primer.tutorials/">associated tutorials</a>. Assignments associated with a specific lecture must be completed before that lecture.</p>
 <p>Completed tutorials are sent to kanes.datacamp@gmail.com with your name and the name of the tutorial separated by a semi-colon — like “Sarah Jones; Getting Started” — in the subject line. If you do not complete the tutorials on time, you will be removed from the class. Send in your tutorial answers saved in <em>rds</em> format. If you want to save a copy for your own records, use <em>html</em>.</p>
 <section id="week-1-visualization" class="level1">
 <h1>Week 1: Visualization</h1>

--- a/philosophy.qmd
+++ b/philosophy.qmd
@@ -35,7 +35,7 @@ Second, "Kill The Math and Let the Introductory Course Be Born" is an [article](
 
 Any introductory course which, for example, does not teach Git/Github is doing its students a disservice.
 
-Third, the heart of the course are the [tutorials](https://ppbds.github.io/primer.tutorials/) which students complete on their own. This [essay](https://ppbds.github.io/primer.tutorials/articles/instructions.html) about how to write tutorials provides some background details. Highlights:
+Third, the heart of the course are the [tutorials](https://ppbds.github.io/all.primer.tutorials/) which students complete on their own. This [essay](https://ppbds.github.io/all.primer.tutorials/articles/instructions.html) about how to write tutorials provides some background details. Highlights:
 
 > Imagine the shallowest possible learning curve. Almost every student should be able to answer almost every Exercise, albeit perhaps with the help of the Hint. There are no hard questions. In fact, there really aren’t questions at all. Instead, there are instructions: Do this. Do that. Next do this other thing.
 

--- a/schedule.qmd
+++ b/schedule.qmd
@@ -8,7 +8,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 Classes run from 8:00 to 9:00 PM EDT on Mondays, Wednesdays and Thursdays.
 
-Two key resources: [*Preceptor's Primer for Bayesian Data Science*](https://ppbds.github.io/primer/) and its [associated tutorials](https://ppbds.github.io/primer.tutorials/). Assignments associated with a specific lecture must be completed before that lecture.
+Two key resources: [*Preceptor's Primer for Bayesian Data Science*](https://ppbds.github.io/primer/) and its [associated tutorials](https://ppbds.github.io/all.primer.tutorials/). Assignments associated with a specific lecture must be completed before that lecture.
 
 Completed tutorials are sent to kanes.datacamp@gmail.com with your name and the name of the tutorial separated by a semi-colon  --- like "Sarah Jones; Getting Started" --- in the subject line. If you do not complete the tutorials on time, you will be removed from the class. Send in your tutorial answers saved in *rds* format. If you want to save a copy for your own records, use *html*. 
 


### PR DESCRIPTION
Updated page links to point to the new tutorials page: https://ppbds.github.io/all.primer.tutorials/